### PR TITLE
Fixing link; clarifying

### DIFF
--- a/development/index.md
+++ b/development/index.md
@@ -5,14 +5,16 @@ title: Development of OpenMath
 
 Various parts of OpenMath are currently under development by members of the
 [OpenMath Society](./society/). Most of the development is organized publicakly via our
-[GitHub Group](https://github.com/OpenMath). Please feel free to contribute by opening
-issues, contributing fixes or extensions via merge requests, or contributing
-OpenMath-related software (we will be happy to give you a repository for that). 
+[GitHub Group](https://github.com/OpenMath), where some notable repositories are:
 
 * [OpenMath Standard](http://github.com/OpenMath/OMSTD)
-* [OpenMath Content Dictionaries](http://github.com/OpenMath/OM3) 
+* [OpenMath Content Dictionaries](http://github.com/OpenMath/CDs) 
 * [OpenMath Web Site](http://github.com/OpenMath/openmath.github.io)
 * [Extensions of OpenMath](http://github.com/OpenMath/OM3)
+
+Please feel free to contribute by opening
+issues, contributing fixes or extensions via merge requests, or contributing
+OpenMath-related software (we will be happy to give you a repository for that).
 
 #### Development Roadmap
 


### PR DESCRIPTION
The link for CDs pointed to the OM3 repository, correcting this.
Also changed text to clarify that the bullet list is one of links to repositories; from the old text I rather expected links to more webpages, which makes the directory listing occupying the first screenfull of a repository view feel like "Someone forgot to put an index.html file here."