### PR TITLE
some link fixes

### DIFF
--- a/_posts/2016-04-12-om27.md
+++ b/_posts/2016-04-12-om27.md
@@ -2,4 +2,4 @@
 layout: post
 title: 27th OpenMath Workshop
 ---
-The  [27th OpenMath Workshop](http://www.cicm-conference.org/2016/cicm.php?event=openmath) will be held  July 25/29 2016 aside of [CICM 2016](http://www.cicm-conference.org/2016) in Bialystok, PL.
+The  [27th OpenMath Workshop](http://www.cicm-conference.org/2016/cicm.php?event=openmath) will be held  July 25/29 2016 aside of [CICM 2016](http://www.cicm-conference.org/2016/) in Bialystok, PL.

--- a/cd/index.md
+++ b/cd/index.md
@@ -12,7 +12,7 @@ indicates the semantics of such symbols such as the set of natural numbers.
   
 CDs are grouped in CD-groups. For example, the [MathML CD group](../cdgroups/mathml.html)
 collects the 'core CDs', all content-dictionaries described in the OpenMath standard
-deemed compatible with the [MathML3 Recommendation](http://www.w3.org/TR/MathML3)
+deemed compatible with the [MathML3 Recommendation](http://www.w3.org/TR/MathML3/)
 
 ## Curation
 

--- a/development/index.md
+++ b/development/index.md
@@ -4,7 +4,7 @@ title: Development of OpenMath
 ---
 
 Various parts of OpenMath are currently under development by members of the
-[OpenMath Society](./society/). Most of the development is organized publicly via our
+[OpenMath Society](society/). Most of the development is organized publicly via our
 [GitHub Group](https://github.com/OpenMath), where some notable repositories are:
 
 * [OpenMath Standard](http://github.com/OpenMath/OMSTD)

--- a/development/index.md
+++ b/development/index.md
@@ -7,10 +7,10 @@ Various parts of OpenMath are currently under development by members of the
 [OpenMath Society](society/). Most of the development is organized publicly via our
 [GitHub Group](https://github.com/OpenMath), where some notable repositories are:
 
-* [OpenMath Standard](http://github.com/OpenMath/OMSTD)
-* [OpenMath Content Dictionaries](http://github.com/OpenMath/CDs) 
-* [OpenMath Web Site](http://github.com/OpenMath/openmath.github.io)
-* [Extensions of OpenMath](http://github.com/OpenMath/OM3)
+* [OpenMath Standard](https://github.com/OpenMath/OMSTD)
+* [OpenMath Content Dictionaries](https://github.com/OpenMath/CDs) 
+* [OpenMath Web Site](https://github.com/OpenMath/openmath.github.io)
+* [Extensions of OpenMath](https://github.com/OpenMath/OM3)
 
 Please feel free to contribute by opening
 issues, contributing fixes or extensions via merge requests, or contributing
@@ -22,7 +22,7 @@ The OpenMath Workshop 2017 determined that the focus of development should be on
 the supply of content dictionaries and language integrations to fix OpenMath's birth
 defect of not having a credible supply. Consequently extending the OpenMath Standard (OM
 Objects and OM Content Dictionaries are deprioritized for the coming year, but we continue
-to collect [extensions proposals](http://github.com/OpenMath/OM3).
+to collect [extensions proposals](https://github.com/OpenMath/OM3).
  
 The current set of projects is
 

--- a/documents/index.md
+++ b/documents/index.md
@@ -22,5 +22,5 @@ which can be used to augment the information in content dictionaries.
 A detailed description of the correspondance between symbols in content MathML
 and the MathML Cd Group.
 * [A discussion document on Units in OpenMath. (PDF)](Units.pdf) 
-* [OpenMath Society Royalty-Free (RF) Licensing Requirements](openmath-ipr)
+* [OpenMath Society Royalty-Free (RF) Licensing Requirements](openmath-ipr/)
 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: OpenMath Home
 
 {% include intro.md %}
 
-Read more ... about [OpenMath](about) and the [OpenMath Society](society)
+Read more ... about [OpenMath](about/) and the [OpenMath Society](society/)
 
 ## News ([older news](news/); [really old news](oldnews/))
 

--- a/meetings/index.md
+++ b/meetings/index.md
@@ -3,8 +3,8 @@ layout: page
 title: OpenMath Workshops
 ---
 
-From time to time various meetings are organised by the [OpenMath Society](../society) and
-by the various associated [OpenMath Projects](../projects).  This page collects slides and
+From time to time various meetings are organised by the [OpenMath Society](../society/) and
+by the various associated [OpenMath Projects](../projects/).  This page collects slides and
 notes from those meetings. The numbering of the workshops somewhat haphazard (and is off
 by 4 for the newest counting), as the naming of the workshops was often governed by
 project requirements.
@@ -16,8 +16,8 @@ project requirements.
 * The 25th OpenMath workshop: [Bath, 2013](http://www.cicm-conference.org/2013/cicm.php?event=openmath&amp;menu=general).
 * The 24th OpenMath workshop: [Bremen, 2012](http://www.cicm-conference.org/2012/cicm.php?event=openmath&amp;menu=general) ([Proceedings](http://ceur-ws.org/Vol-921/)).
 * The 23rd OpenMath workshop: [Paris 2010](http://cicm2010.cnam.fr/om/).
-* The 22nd OpenMath workshop: [Grand Bend 2009](22).
-* The 21st OpenMath workshop: [Linz 2007](linz2007).
+* The 22nd OpenMath workshop: [Grand Bend 2009](22/).
+* The 21st OpenMath workshop: [Linz 2007](linz2007/).
 * The 7th [Thematic Network](../projects/thematic/) workshop, [Helsinki 2004: ten years of OpenMath](helsinki2004/).
 * The 6th [Thematic Network](../projects/thematic/) workshop, [Bremen November 2003](bremen2003/).
 * The 5th [Thematic Network](../projects/thematic/) workshop, [Mathematics On The Semantic Web (Eindhoven) May 2003](eindhoven2003/).

--- a/society/index.md
+++ b/society/index.md
@@ -13,7 +13,7 @@ The OpenMath Society is coordinated by an [executive committee](board), governed
 * Through its [Editorial Board for Content Dictionaries](cdeb) it curates a set of
   [Content Dictionaries](/cd/) that give meaning to OpenMath Objects. 
 * It also supports dissemination about OpenMath by hosting a number of
-[discussion lists](../follow/index.html#follow-us-with our-two-open-mailing-lists), and
+[discussion lists](../follow/index.html#follow-us-with-our-two-open-mailing-lists), and
 information about the [Openmath standards](/standard/) and
 [Content Dictionaries](/cd/).
 

--- a/society/index.md
+++ b/society/index.md
@@ -7,9 +7,9 @@ The worldwide OpenMath activities are coordinated within the OpenMath Society, b
 Helsinki, Finland.  The Society brings together mathematical tool builders, software
 suppliers, publishers and authors.
 
-The OpenMath Society is coordinated by an [executive committee](board), governed by its
-[members](members) according to its [statutes](statutes).
-* It organizes [workshops](../meetings) and [business meetings](business-meetings).
+The OpenMath Society is coordinated by an [executive committee](board/), governed by its
+[members](members/) according to its [statutes](statutes/).
+* It organizes [workshops](../meetings/) and [business meetings](business-meetings/).
 * Through its [Editorial Board for Content Dictionaries](cdeb) it curates a set of
   [Content Dictionaries](/cd/) that give meaning to OpenMath Objects. 
 * It also supports dissemination about OpenMath by hosting a number of
@@ -19,6 +19,6 @@ information about the [Openmath standards](/standard/) and
 
 These dissemination activities are supported by the [infrastructure group](infrastructure/).
 
-To become a [member](members), you have to show a record of working with OpenMath (or
+To become a [member](members/), you have to show a record of working with OpenMath (or
 related maths representation formats) and apply [by e-mail](mailto:om-sc@openmath.org) to
-the [executive committee](board).
+the [executive committee](board/).

--- a/software/index.md
+++ b/software/index.md
@@ -11,7 +11,7 @@ If you have developed any OpenMath software that should be listed here, please s
 ## OpenMath Phrasebooks
 
 * A phrasebook for [AXIOM 2.3](http://www.nag.co.uk) was shipped with the system.
-* A phrasebook for GAP 4 is available from the [GAP 4 website](http://www-history.mcs.st-and.ac.uk/~gap/).
+* A phrasebook for GAP 4 is available from the [GAP 4 website](http://www.gap-system.org/).
 * A phrasebook for Mathematica has been developed by [INRIA](mailto:stephane.dalmas@sophia.inria.fr).
 * Various phrasebooks for GAP, Magma and Mathematica are available from [RIACA](http://www.riaca.win.tue.nl/products/).
 
@@ -27,7 +27,7 @@ If you have developed any OpenMath software that should be listed here, please s
 * [An OpenMath Shell](http://www.riaca.win.tue.nl/products/) for sending OpenMath to a computational engine. 
 * [A computation service using GAP](http://www.riaca.win.tue.nl/products/)
 * [A computation service using Mathematica](http://www.riaca.win.tue.nl/products/)
-* [LaTeX to OpenMath translator demo ](http://www.maths.tcd.ie/~richardt/openmath) 
+* [LaTeX to OpenMath translator demo ](http://www.maths.tcd.ie/~richardt/openmath/) 
 * [OpenMath to LaTeX translator demo ](http://www.maths.tcd.ie/~dwmalone/om2la.html) 
 * [QMath](http://www.matracas.org/qmath/), a tool to produce OpenMath and OMDoc with a text-based input syntax 
 
@@ -62,7 +62,7 @@ If you have developed any OpenMath software that should be listed here, please s
 * [Sentido](http://www.matracas.org/sentido/) is a visual and linear formula editor for OpenMath objects.  It is not currently available for standalone download, but integrated into the SWiM wiki (see above).
 * [RIACA CD Editor](http://www.riaca.win.tue.nl/download/om/cd/editor/).
 * [The JOME OpenMath Editor](http://www.activemath.org/projects/Jome/) for creating and manipulating OpenMath objects.
-  The source code is available from [sourceforge](http://sourceforge.net/projects/jome/).
+  The source code is available from [sourceforge](https://sourceforge.net/projects/jome/).
 * STARS/MathWriter: A Java component which takes a simple linear input and generates
   OpenMath or MathML.  For details contact [Stilo Technology](mailto:sb@stilo.com).
 

--- a/standard/index.md
+++ b/standard/index.md
@@ -8,13 +8,13 @@ title: The OpenMath Standards
 The Normative version of the OpenMath Standard is<br/>
 [OpenMath Version 2.0 Revision 1](om20-2017-07-22).
 
-An [Editor's draft of possible revisions of OpenMath 2.0](om20-editors-draft) is also available.
+An [Editor's draft of possible revisions of OpenMath 2.0](om20-editors-draft/) is also available.
 
 
 ### Older versions:
-[OpenMath Version 2.0](om20-2004-06-30),
-[OpenMath Version 1.1](om11),
-[OpenMath Version 1.0](om10)
+[OpenMath Version 2.0](om20-2004-06-30/),
+[OpenMath Version 1.1](om11/),
+[OpenMath Version 1.0](om10/)
 
 
 
@@ -26,7 +26,7 @@ is [SCSCP Version 1.3](https://github.com/OpenMath/scscp/blob/master/revisions/S
 [SCSCP Version 1.1](https://github.com/OpenMath/scscp/blob/master/revisions/SCSCP_1_1.pdf)
 and [SCSCP Version 1.2](https://github.com/OpenMath/scscp/blob/master/revisions/SCSCP_1_2.pdf) are also available.
 
-For further information, see the SCSCP page [here](scscp).
+For further information, see the SCSCP page [here](scscp/).
 
 ## Associated Documents
 


### PR DESCRIPTION
mostly redirect fixes (http -> https, added trailing /)
gap link now points to http://www.gap-system.org/
fix in society/index.md (discussion lists)
fix in development/index.md (openmath society)